### PR TITLE
cuda-nvprune v13.1.115

### DIFF
--- a/.ci_support/linux_64_.yaml
+++ b/.ci_support/linux_64_.yaml
@@ -6,8 +6,6 @@ c_stdlib:
 - sysroot
 c_stdlib_version:
 - '2.17'
-cdt_name:
-- conda
 channel_sources:
 - conda-forge
 channel_targets:

--- a/.ci_support/linux_aarch64_.yaml
+++ b/.ci_support/linux_aarch64_.yaml
@@ -6,8 +6,6 @@ c_stdlib:
 - sysroot
 c_stdlib_version:
 - '2.17'
-cdt_name:
-- conda
 channel_sources:
 - conda-forge
 channel_targets:

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 # Ignore all files and folders in root
 *
 !/conda-forge.yml
+!/abs.yaml
 
 # Don't ignore any files/folders if the parent folder is 'un-ignored'
 # This also avoids warnings when adding an already-checked file with an ignored parent.

--- a/README.md
+++ b/README.md
@@ -137,12 +137,12 @@ it is possible to build and upload installable packages to the
 [conda-forge](https://anaconda.org/conda-forge) [anaconda.org](https://anaconda.org/)
 channel for Linux, Windows and OSX respectively.
 
-To manage the continuous integration and simplify feedstock maintenance
+To manage the continuous integration and simplify feedstock maintenance,
 [conda-smithy](https://github.com/conda-forge/conda-smithy) has been developed.
 Using the ``conda-forge.yml`` within this repository, it is possible to re-render all of
 this feedstock's supporting files (e.g. the CI configuration files) with ``conda smithy rerender``.
 
-For more information please check the [conda-forge documentation](https://conda-forge.org/docs/).
+For more information, please check the [conda-forge documentation](https://conda-forge.org/docs/).
 
 Terminology
 ===========
@@ -169,7 +169,7 @@ merged, the recipe will be re-built and uploaded automatically to the
 everybody to install and use from the `conda-forge` channel.
 Note that all branches in the conda-forge/cuda-nvprune-feedstock are
 immediately built and any created packages are uploaded, so PRs should be based
-on branches in forks and branches in the main repository should only be used to
+on branches in forks, and branches in the main repository should only be used to
 build distinct package versions.
 
 In order to produce a uniquely identifiable distribution:

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,9 @@
+build_parameters:
+  - "--suppress-variables"
+  #- "--skip-existing"
+  - "--error-overlinking"
+
+staging_channel_upload_target: ctk-13.1.1-build-1
+
+channels:
+  - https://staging.continuum.io/pbp/ctk-13.1.1-build-1

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "cuda-nvprune" %}
-{% set version = "13.0.85" %}
-{% set cuda_version = "13.0" %}
+{% set version = "13.1.80" %}
+{% set cuda_version = "13.1" %}
 {% set platform = "linux-x86_64" %}  # [linux64]
 {% set platform = "linux-ppc64le" %}  # [ppc64le]
 {% set platform = "linux-sbsa" %}  # [aarch64]
@@ -14,9 +14,9 @@ package:
 
 source:
   url: https://developer.download.nvidia.com/compute/cuda/redist/cuda_nvprune/{{ platform }}/cuda_nvprune-{{ platform }}-{{ version }}-archive.{{ extension }}
-  sha256: b182d8b0398ba9ff8ee75fc2ffef3ff1e2069e6bec6938bcf02a6c9e69d40456  # [linux64]
-  sha256: 956e1f1b282522ff40b331e5cea83b5d7a87bd97cd9c2bea3454bb0c6adf5414  # [aarch64]
-  sha256: b52ca2d51d0e41c317f68f38ce88f4ae7184443eac04203e7a80fd054f2028ec  # [win]
+  sha256: b459d0342098bc362636ded5a39c5ed5a05b429cb50c5b354e3820e6ea763275  # [linux64]
+  sha256: bf2de825d84481fb3d37c2a6718033fd6691ce40e8e480aff4dcc856910e90f3  # [aarch64]
+  sha256: 12dcd8d89bd70b8bc61b88abd995a8364b692ddfc5bea1fd424ff0f5ed74de1a  # [win]
 
 build:
   number: 0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "cuda-nvprune" %}
-{% set version = "13.1.80" %}
+{% set version = "13.1.115" %}
 {% set cuda_version = "13.1" %}
 {% set platform = "linux-x86_64" %}  # [linux64]
 {% set platform = "linux-ppc64le" %}  # [ppc64le]
@@ -14,9 +14,9 @@ package:
 
 source:
   url: https://developer.download.nvidia.com/compute/cuda/redist/cuda_nvprune/{{ platform }}/cuda_nvprune-{{ platform }}-{{ version }}-archive.{{ extension }}
-  sha256: b459d0342098bc362636ded5a39c5ed5a05b429cb50c5b354e3820e6ea763275  # [linux64]
-  sha256: bf2de825d84481fb3d37c2a6718033fd6691ce40e8e480aff4dcc856910e90f3  # [aarch64]
-  sha256: 12dcd8d89bd70b8bc61b88abd995a8364b692ddfc5bea1fd424ff0f5ed74de1a  # [win]
+  sha256: c7149dec758408511950df3a60a7a3831a589fbc27f268b5c46fc219eca0ab31  # [linux64]
+  sha256: a1113c8c70ca66ce10fa15c3794ae4bb3e139a2cffcc5d0223241497b851f70d  # [aarch64]
+  sha256: 78c313b1dbee68aa9606626b53922ea312fbefe2fe0fdd2336c46cd4ccd4ebad  # [win]
 
 build:
   number: 0


### PR DESCRIPTION
cuda-nvprune 13.1.115

**Destination channel:** defaults

### Links

- [PKG-12010](https://anaconda.atlassian.net/browse/PKG-12010) 
- Relevant dependency PRs:
  - ...

### Explanation of changes:

- CUDA 13.1 release


[PKG-12010]: https://anaconda.atlassian.net/browse/PKG-12010?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ