### PR TITLE
cuda-nvprune v12.9.82

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 # Ignore all files and folders in root
 *
 !/conda-forge.yml
+!/abs.yaml
 
 # Don't ignore any files/folders if the parent folder is 'un-ignored'
 # This also avoids warnings when adding an already-checked file with an ignored parent.

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,9 @@
+# build_parameters:
+#   - "--suppress-variables"
+#   #- "--skip-existing"
+#   - "--error-overlinking"
+
+# staging_channel_upload_target: ctk-12.9-build-4
+
+# channels:
+#   - https://staging.continuum.io/pbp/ctk-12.9-build-4

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,3 +1,4 @@
+# Please see the note on "arm-variant-feedstock" cbc.yaml file regarding tegra builds
 arm_variant_type: # [aarch64]
   - sbsa          # [aarch64]
-  - tegra         # [aarch64]
+#  - tegra         # [aarch64]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -23,9 +23,9 @@ source:
   sha256: be23018507f015ca948c503a43a3c48449c0dc1ceaab1e721caf01f024727312  # [win]
 
 build:
-  number: 1
+  number: 0
   binary_relocation: false
-  skip: true  # [osx or ppc64le]
+  skip: true  # [osx]
 
 requirements:
   build:
@@ -54,11 +54,13 @@ about:
   license_file: LICENSE
   license: LicenseRef-NVIDIA-End-User-License-Agreement
   license_url: https://docs.nvidia.com/cuda/eula/index.html
+  license_family: Other
   summary: Prunes host object files and libraries to only contain device code
   description: |
     Prunes host object files and libraries to only contain device code for the
     specified targets.
   doc_url: https://docs.nvidia.com/cuda/index.html
+  dev_url: https://docs.nvidia.com/cuda/index.html
 
 extra:
   recipe-maintainers:


### PR DESCRIPTION
cuda-nvprune v12.9.82

**Destination channel:** defaults

### Links

- [PKG-12776](https://anaconda.atlassian.net/browse/PKG-12776) 
- [CUDA 12.9 release notes](https://docs.nvidia.com/cuda/archive/12.9.1/cuda-toolkit-release-notes/index.html) for list of packages, version numbers, etc.

### Explanation of changes:

- CUDA 12.9 release
- Added `abs.yaml` for possible use of staging channels in future builds

[PKG-12776]: https://anaconda.atlassian.net/browse/PKG-12776?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ